### PR TITLE
chore(OctToken): remove TOTAL_SUPPLY

### DIFF
--- a/contracts/OctToken.sol
+++ b/contracts/OctToken.sol
@@ -6,13 +6,10 @@ import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 
 contract OctToken is ERC20, Ownable {
-    // Total supply: 100 million
-    uint256 private constant TOTAL_SUPPLY = 100000000;
-
     /**
-     * @dev Initializes the contract, mint total supply to the deployer (owner).
+     * @dev Initializes the contract, mint total supply of 100 million to the deployer (owner).
      */
     constructor() ERC20("Octopus Network Token", "OCT") {
-        _mint(msg.sender, TOTAL_SUPPLY * 10**(uint256(decimals())));
+        _mint(msg.sender, 100_000_000 * 10**(uint256(decimals())));
     }
 }


### PR DESCRIPTION
I believe that this Total_supply constant is not necessary, it makes the contract lighter and lowers its cost to deploy

change total TOTAL_SUPPLY to 100_000_000.

And another thing ERC20 already has a [function totalSupply()](https://docs.openzeppelin.com/contracts/3.x/api/token/erc20#ERC20-totalSupply--) that returns the total tokens.